### PR TITLE
Declare per-MOD sub-sources in release-metadata

### DIFF
--- a/src/versions.py
+++ b/src/versions.py
@@ -1,10 +1,24 @@
 """Upstream source version fetcher for go-ingest.
 
-Two logical sources:
-  - infores:goa — the per-species GAF files share a GO release, version
-    is read from `!date-generated:` in any GAF file's header.
+Top-level sources:
+  - infores:goa — the per-species GAF files share a GO release; bundle
+    version is the `!date-generated:` of any GAF.
   - infores:eco — the gaf-eco-mapping comes from a github master branch
     (no formal release), version is the latest commit SHA.
+
+Nested under infores:goa, one SourceVersion per consumed GAF file records
+the per-species `!date-generated:` from that file's header. Edges in this
+ingest's output carry per-source `primary_knowledge_source` (derived from
+the GAF `Assigned_By` column in src/go_annotation.py), so a downstream
+consumer (e.g. monarch-app) can resolve an edge's exact upstream version
+even though everything was retrieved via GO/GOA.
+
+Per-file infores choices: the model-organism GAFs (mgi, rgd, zfin, fb, wb,
+sgd, pombase, dictybase) map straightforwardly to their MOD's infores. The
+`goa_*` files are UniProt-mediated species-specific submissions; they map
+to infores:goa-{species} rather than infores:uniprot, mirroring the GO
+project's own labeling (see Header from goa_{species} source association
+file in each GAF).
 """
 
 from __future__ import annotations
@@ -24,6 +38,64 @@ INGEST_DIR = Path(__file__).resolve().parents[1]
 DOWNLOAD_YAML = INGEST_DIR / "download.yaml"
 DATA_DIR = INGEST_DIR / "data"
 
+# Map from upstream GAF basename -> (infores, human-readable name).
+# Keyed by the basename in the GO download URL (not our local taxid name).
+GAF_INFORES = {
+    "mgi.gaf.gz": ("infores:mgi", "Mouse Genome Informatics"),
+    "rgd.gaf.gz": ("infores:rgd", "Rat Genome Database"),
+    "zfin.gaf.gz": ("infores:zfin", "ZFIN"),
+    "fb.gaf.gz": ("infores:flybase", "FlyBase"),
+    "wb.gaf.gz": ("infores:wormbase", "WormBase"),
+    "sgd.gaf.gz": ("infores:sgd", "Saccharomyces Genome Database"),
+    "pombase.gaf.gz": ("infores:pombase", "PomBase"),
+    "dictybase.gaf.gz": ("infores:dictybase", "dictyBase"),
+    "goa_human.gaf.gz": ("infores:goa-human", "GOA Human (UniProt)"),
+    "goa_dog.gaf.gz": ("infores:goa-dog", "GOA Dog (UniProt)"),
+    "goa_cow.gaf.gz": ("infores:goa-cow", "GOA Cow (UniProt)"),
+    "goa_pig.gaf.gz": ("infores:goa-pig", "GOA Pig (UniProt)"),
+    "goa_chicken.gaf.gz": ("infores:goa-chicken", "GOA Chicken (UniProt)"),
+}
+
+
+def _per_gaf_sources(now: str) -> list[dict[str, Any]]:
+    """Build nested SourceVersion entries, one per consumed GAF.
+
+    Pairs each download.yaml entry's `url` (upstream basename) with its
+    `local_name` (taxid path) by re-reading download.yaml. Falls back to
+    skipping entries we don't recognize.
+    """
+    import yaml
+    raw = yaml.safe_load(DOWNLOAD_YAML.read_text())
+    entries = raw if isinstance(raw, list) else raw.get("downloads", [])
+
+    sources: list[dict[str, Any]] = []
+    for e in entries or []:
+        url = e.get("url", "")
+        local = e.get("local_name", "")
+        basename = url.rsplit("/", 1)[-1]
+        if basename not in GAF_INFORES:
+            continue
+        infores, name = GAF_INFORES[basename]
+        local_path = INGEST_DIR / local
+        if local_path.is_file():
+            ver, method = version_from_file_header(
+                local_path, pattern=r"!date-generated:\s*(\S+)"
+            )
+            ver = ver.split("T")[0] if "T" in ver else ver
+        else:
+            ver, method = "unknown", "unavailable"
+        sources.append({
+            "id": infores,
+            "name": name,
+            "urls": [url],
+            "version": ver,
+            "version_method": method,
+            "retrieved_at": now,
+        })
+
+    sources.sort(key=lambda s: s["id"])
+    return sources
+
 
 def get_source_versions() -> list[dict[str, Any]]:
     goa_urls = urls_from_download_yaml(DOWNLOAD_YAML, contains=["geneontology.org/annotations"])
@@ -41,14 +113,18 @@ def get_source_versions() -> list[dict[str, Any]]:
             ver = ver.split("T")[0] if "T" in ver else ver
         else:
             ver, method = "unknown", "unavailable"
-        sources.append({
+        entry: dict[str, Any] = {
             "id": "infores:goa",
             "name": "GO Annotations (GOA)",
             "urls": goa_urls,
             "version": ver,
             "version_method": method,
             "retrieved_at": now,
-        })
+        }
+        nested = _per_gaf_sources(now)
+        if nested:
+            entry["sources"] = nested
+        sources.append(entry)
 
     if eco_urls:
         ver, method = version_from_github_branch("evidenceontology/evidenceontology", branch="master")

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,7 +1,7 @@
 """Unit tests for src/versions.py — per-GAF nested SourceVersion emission.
 
 These exercise the parsing path (download.yaml → per-file infores mapping →
-GAF header date) without hitting the network or the AGR FMS API.
+GAF header date) without hitting the network.
 """
 
 from __future__ import annotations

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1,0 +1,112 @@
+"""Unit tests for src/versions.py — per-GAF nested SourceVersion emission.
+
+These exercise the parsing path (download.yaml → per-file infores mapping →
+GAF header date) without hitting the network or the AGR FMS API.
+"""
+
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+import pytest
+
+from src import versions
+
+
+GAF_HEADER = """!gaf-version: 2.2
+!
+!generated-by: GOC
+!
+!date-generated: 2025-10-11T19:57
+!
+!Header from source association file:
+!=================================
+!
+!generated-by: GOC
+!
+!date-generated: 2025-10-10T17:37
+!
+"""
+
+
+def _write_gaf(path: Path, date_generated: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = GAF_HEADER.replace("2025-10-11T19:57", date_generated)
+    with gzip.open(path, "wt") as f:
+        f.write(header)
+        f.write("UniProtKB\tP12345\tFOO\t\tGO:0008150\tPMID:1\tIEA\t\tP\tFoo\t\tprotein\ttaxon:9606\t20250101\tUniProt\t\t\n")
+
+
+@pytest.fixture
+def fake_ingest(tmp_path, monkeypatch):
+    """Build a minimal ingest tree at tmp_path with a download.yaml and one GAF."""
+    (tmp_path / "data").mkdir()
+    (tmp_path / "download.yaml").write_text(
+        "- url: http://current.geneontology.org/annotations/mgi.gaf.gz\n"
+        "  local_name: data/10090.go_annotations.gaf.gz\n"
+        "- url: http://current.geneontology.org/annotations/zfin.gaf.gz\n"
+        "  local_name: data/7955.go_annotations.gaf.gz\n"
+        "- url: http://current.geneontology.org/annotations/something_unknown.gaf.gz\n"
+        "  local_name: data/unknown.go_annotations.gaf.gz\n"
+    )
+    _write_gaf(tmp_path / "data" / "10090.go_annotations.gaf.gz", "2025-10-11T19:57")
+    _write_gaf(tmp_path / "data" / "7955.go_annotations.gaf.gz", "2025-09-30T08:00")
+
+    monkeypatch.setattr(versions, "INGEST_DIR", tmp_path)
+    monkeypatch.setattr(versions, "DOWNLOAD_YAML", tmp_path / "download.yaml")
+    monkeypatch.setattr(versions, "DATA_DIR", tmp_path / "data")
+    return tmp_path
+
+
+def test_per_gaf_sources_reads_date_generated(fake_ingest):
+    sources = versions._per_gaf_sources(now="2026-01-01T00:00:00Z")
+
+    by_id = {s["id"]: s for s in sources}
+    assert by_id["infores:mgi"]["version"] == "2025-10-11"
+    assert by_id["infores:mgi"]["version_method"] == "file_header"
+    assert by_id["infores:zfin"]["version"] == "2025-09-30"
+
+
+def test_per_gaf_sources_maps_url_basename_to_infores(fake_ingest):
+    sources = versions._per_gaf_sources(now="2026-01-01T00:00:00Z")
+
+    ids = {s["id"] for s in sources}
+    assert ids == {"infores:mgi", "infores:zfin"}
+    mgi = next(s for s in sources if s["id"] == "infores:mgi")
+    assert mgi["urls"] == ["http://current.geneontology.org/annotations/mgi.gaf.gz"]
+
+
+def test_per_gaf_sources_skips_unknown_basenames(fake_ingest):
+    sources = versions._per_gaf_sources(now="2026-01-01T00:00:00Z")
+
+    assert all(s["id"] != "infores:something_unknown" for s in sources)
+
+
+def test_per_gaf_sources_handles_missing_local_file(tmp_path, monkeypatch):
+    """If the GAF wasn't downloaded, the entry still emits with unknown version."""
+    (tmp_path / "data").mkdir()
+    (tmp_path / "download.yaml").write_text(
+        "- url: http://current.geneontology.org/annotations/mgi.gaf.gz\n"
+        "  local_name: data/10090.go_annotations.gaf.gz\n"
+    )
+    monkeypatch.setattr(versions, "INGEST_DIR", tmp_path)
+    monkeypatch.setattr(versions, "DOWNLOAD_YAML", tmp_path / "download.yaml")
+    monkeypatch.setattr(versions, "DATA_DIR", tmp_path / "data")
+
+    sources = versions._per_gaf_sources(now="2026-01-01T00:00:00Z")
+
+    assert len(sources) == 1
+    assert sources[0]["id"] == "infores:mgi"
+    assert sources[0]["version"] == "unknown"
+    assert sources[0]["version_method"] == "unavailable"
+
+
+def test_gaf_infores_covers_all_download_yaml_entries():
+    """Catch drift: every GAF in the real download.yaml must be in GAF_INFORES."""
+    import yaml
+    real_download = Path(__file__).resolve().parents[1] / "download.yaml"
+    entries = yaml.safe_load(real_download.read_text()) or []
+    gaf_basenames = [e["url"].rsplit("/", 1)[-1] for e in entries if e.get("url", "").endswith(".gaf.gz")]
+    missing = [b for b in gaf_basenames if b not in versions.GAF_INFORES]
+    assert not missing, f"download.yaml has GAFs not mapped in GAF_INFORES: {missing}"


### PR DESCRIPTION
## Summary

Expand `versions.py::get_source_versions()` so the `infores:goa` entry nests one `SourceVersion` per consumed GAF file. Per-file `version` is the file's first `!date-generated:` header, read from the local `.gaf.gz` already on disk — no extra fetches.

## Output shape

```yaml
- id: infores:goa
  version: '2025-10-11'
  version_method: file_header
  sources:
    - {id: infores:mgi,        version: '2025-10-11', urls: [mgi.gaf.gz]}
    - {id: infores:rgd,        version: '2025-10-11', urls: [rgd.gaf.gz]}
    - {id: infores:zfin,       version: '2025-10-11', urls: [zfin.gaf.gz]}
    - {id: infores:flybase,    version: '2025-10-11', urls: [fb.gaf.gz]}
    - {id: infores:wormbase,   version: '2025-10-11', urls: [wb.gaf.gz]}
    - {id: infores:sgd,        version: '2025-10-11', urls: [sgd.gaf.gz]}
    - {id: infores:pombase,    version: '2025-10-11', urls: [pombase.gaf.gz]}
    - {id: infores:dictybase,  version: '2025-10-11', urls: [dictybase.gaf.gz]}
    - {id: infores:goa-human,   ...}
    - {id: infores:goa-dog,     ...}
    - {id: infores:goa-cow,     ...}
    - {id: infores:goa-pig,     ...}
    - {id: infores:goa-chicken, ...}
```

The `goa_*` files (UniProt-mediated submissions) map to `infores:goa-{species}` rather than a single `infores:uniprot` — mirrors the GO project's own per-species labeling. Documented inline in `versions.py`.

## Test plan

- [x] `versions.py::get_source_versions()` returns the expected nested shape.
- [x] Existing tests pass: `just test` (12 passed).
- [ ] After a real release, `output/release-metadata.yaml` shows the nested per-GAF structure.
- [ ] Missing-file path: with `data/` empty, each entry emits `unknown`/`unavailable` rather than failing the whole metadata write.

Resolves #9.