### PR TITLE
Migrate GO annotation download URLs to new /annotations/gaf/ layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Gene Ontology](http://geneontology.org/) provides annotations linking genes to GO terms describing molecular functions, biological processes, and cellular components.
 
-Data is downloaded from: `http://current.geneontology.org/annotations/`
+Data is downloaded from: `http://current.geneontology.org/annotations/gaf/`
 
 ### Species Included
 

--- a/download.yaml
+++ b/download.yaml
@@ -8,67 +8,72 @@
 - url: https://raw.githubusercontent.com/evidenceontology/evidenceontology/master/gaf-eco-mapping.txt
   local_name: data/gaf-eco-mapping.txt
 
+# NOTE: As of the June 2026 GO pipeline migration (geneontology/go-announcements#1153)
+# annotation files live under /annotations/gaf/ and are named with UniProt mnemonic
+# organism codes. MOD-submitted species use the `-mod` (MOD ID-centric) variant to
+# preserve MOD-namespace gene identifiers; UniProt-mediated species use `-uniprot`.
+
 # Homo sapiens (human)
-- url: http://current.geneontology.org/annotations/goa_human.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/HUMAN-uniprot.gaf.gz
   local_name: data/9606.go_annotations.gaf.gz
   tag: go_annotation
 
 # Mus musculus (house mouse)
-- url: http://current.geneontology.org/annotations/mgi.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/MOUSE-mod.gaf.gz
   local_name: data/10090.go_annotations.gaf.gz
   tag: go_annotation
 
 # Rattus norvegicus (Norway rat)
-- url: http://current.geneontology.org/annotations/rgd.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/RAT-mod.gaf.gz
   local_name: data/10116.go_annotations.gaf.gz
   tag: go_annotation
 
 # Canis lupus familiaris (dog)
-- url: http://current.geneontology.org/annotations/goa_dog.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/CANLF-uniprot.gaf.gz
   local_name: data/9615.go_annotations.gaf.gz
   tag: go_annotation
 
 # Bos taurus (cow)
-- url: http://current.geneontology.org/annotations/goa_cow.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/BOVIN-uniprot.gaf.gz
   local_name: data/9913.go_annotations.gaf.gz
   tag: go_annotation
 
 # Sus scrofa (pig)
-- url: http://current.geneontology.org/annotations/goa_pig.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/PIG-uniprot.gaf.gz
   local_name: data/9823.go_annotations.gaf.gz
   tag: go_annotation
 
 # Gallus gallus (chicken)
-- url: http://current.geneontology.org/annotations/goa_chicken.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/CHICK-uniprot.gaf.gz
   local_name: data/9031.go_annotations.gaf.gz
   tag: go_annotation
 
 # Danio rerio (Zebrafish)
-- url: http://current.geneontology.org/annotations/zfin.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/DANRE-mod.gaf.gz
   local_name: data/7955.go_annotations.gaf.gz
   tag: go_annotation
 
 # Drosophila melanogaster (fruit fly)
-- url: http://current.geneontology.org/annotations/fb.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/DROME-mod.gaf.gz
   local_name: data/7227.go_annotations.gaf.gz
   tag: go_annotation
 
 # Caenorhabditis elegans (nematodes)
-- url: http://current.geneontology.org/annotations/wb.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/CAEEL-mod.gaf.gz
   local_name: data/6239.go_annotations.gaf.gz
   tag: go_annotation
 
 # Dictyostelium discoideum
-- url: http://current.geneontology.org/annotations/dictybase.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/DICDI-mod.gaf.gz
   local_name: data/44689.go_annotations.gaf.gz
   tag: go_annotation
 
 # Saccharomyces cerevisiae (baker's yeast)
-- url: http://current.geneontology.org/annotations/sgd.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/YEAST-mod.gaf.gz
   local_name: data/4932.go_annotations.gaf.gz
   tag: go_annotation
 
 # Schizosaccharomyces pombe (fission yeast)
-- url: http://current.geneontology.org/annotations/pombase.gaf.gz
+- url: http://current.geneontology.org/annotations/gaf/SCHPO-mod.gaf.gz
   local_name: data/4896.go_annotations.gaf.gz
   tag: go_annotation

--- a/src/versions.py
+++ b/src/versions.py
@@ -40,20 +40,25 @@ DATA_DIR = INGEST_DIR / "data"
 
 # Map from upstream GAF basename -> (infores, human-readable name).
 # Keyed by the basename in the GO download URL (not our local taxid name).
+#
+# As of the June 2026 GO pipeline migration (geneontology/go-announcements#1153)
+# these basenames use UniProt mnemonic organism codes under /annotations/gaf/.
+# MOD-submitted species use the `-mod` (MOD ID-centric) variant; UniProt-mediated
+# species use `-uniprot`.
 GAF_INFORES = {
-    "mgi.gaf.gz": ("infores:mgi", "Mouse Genome Informatics"),
-    "rgd.gaf.gz": ("infores:rgd", "Rat Genome Database"),
-    "zfin.gaf.gz": ("infores:zfin", "ZFIN"),
-    "fb.gaf.gz": ("infores:flybase", "FlyBase"),
-    "wb.gaf.gz": ("infores:wormbase", "WormBase"),
-    "sgd.gaf.gz": ("infores:sgd", "Saccharomyces Genome Database"),
-    "pombase.gaf.gz": ("infores:pombase", "PomBase"),
-    "dictybase.gaf.gz": ("infores:dictybase", "dictyBase"),
-    "goa_human.gaf.gz": ("infores:goa-human", "GOA Human (UniProt)"),
-    "goa_dog.gaf.gz": ("infores:goa-dog", "GOA Dog (UniProt)"),
-    "goa_cow.gaf.gz": ("infores:goa-cow", "GOA Cow (UniProt)"),
-    "goa_pig.gaf.gz": ("infores:goa-pig", "GOA Pig (UniProt)"),
-    "goa_chicken.gaf.gz": ("infores:goa-chicken", "GOA Chicken (UniProt)"),
+    "MOUSE-mod.gaf.gz": ("infores:mgi", "Mouse Genome Informatics"),
+    "RAT-mod.gaf.gz": ("infores:rgd", "Rat Genome Database"),
+    "DANRE-mod.gaf.gz": ("infores:zfin", "ZFIN"),
+    "DROME-mod.gaf.gz": ("infores:flybase", "FlyBase"),
+    "CAEEL-mod.gaf.gz": ("infores:wormbase", "WormBase"),
+    "YEAST-mod.gaf.gz": ("infores:sgd", "Saccharomyces Genome Database"),
+    "SCHPO-mod.gaf.gz": ("infores:pombase", "PomBase"),
+    "DICDI-mod.gaf.gz": ("infores:dictybase", "dictyBase"),
+    "HUMAN-uniprot.gaf.gz": ("infores:goa-human", "GOA Human (UniProt)"),
+    "CANLF-uniprot.gaf.gz": ("infores:goa-dog", "GOA Dog (UniProt)"),
+    "BOVIN-uniprot.gaf.gz": ("infores:goa-cow", "GOA Cow (UniProt)"),
+    "PIG-uniprot.gaf.gz": ("infores:goa-pig", "GOA Pig (UniProt)"),
+    "CHICK-uniprot.gaf.gz": ("infores:goa-chicken", "GOA Chicken (UniProt)"),
 }
 
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -43,11 +43,11 @@ def fake_ingest(tmp_path, monkeypatch):
     """Build a minimal ingest tree at tmp_path with a download.yaml and one GAF."""
     (tmp_path / "data").mkdir()
     (tmp_path / "download.yaml").write_text(
-        "- url: http://current.geneontology.org/annotations/mgi.gaf.gz\n"
+        "- url: http://current.geneontology.org/annotations/gaf/MOUSE-mod.gaf.gz\n"
         "  local_name: data/10090.go_annotations.gaf.gz\n"
-        "- url: http://current.geneontology.org/annotations/zfin.gaf.gz\n"
+        "- url: http://current.geneontology.org/annotations/gaf/DANRE-mod.gaf.gz\n"
         "  local_name: data/7955.go_annotations.gaf.gz\n"
-        "- url: http://current.geneontology.org/annotations/something_unknown.gaf.gz\n"
+        "- url: http://current.geneontology.org/annotations/gaf/something_unknown.gaf.gz\n"
         "  local_name: data/unknown.go_annotations.gaf.gz\n"
     )
     _write_gaf(tmp_path / "data" / "10090.go_annotations.gaf.gz", "2025-10-11T19:57")
@@ -74,7 +74,7 @@ def test_per_gaf_sources_maps_url_basename_to_infores(fake_ingest):
     ids = {s["id"] for s in sources}
     assert ids == {"infores:mgi", "infores:zfin"}
     mgi = next(s for s in sources if s["id"] == "infores:mgi")
-    assert mgi["urls"] == ["http://current.geneontology.org/annotations/mgi.gaf.gz"]
+    assert mgi["urls"] == ["http://current.geneontology.org/annotations/gaf/MOUSE-mod.gaf.gz"]
 
 
 def test_per_gaf_sources_skips_unknown_basenames(fake_ingest):
@@ -87,7 +87,7 @@ def test_per_gaf_sources_handles_missing_local_file(tmp_path, monkeypatch):
     """If the GAF wasn't downloaded, the entry still emits with unknown version."""
     (tmp_path / "data").mkdir()
     (tmp_path / "download.yaml").write_text(
-        "- url: http://current.geneontology.org/annotations/mgi.gaf.gz\n"
+        "- url: http://current.geneontology.org/annotations/gaf/MOUSE-mod.gaf.gz\n"
         "  local_name: data/10090.go_annotations.gaf.gz\n"
     )
     monkeypatch.setattr(versions, "INGEST_DIR", tmp_path)


### PR DESCRIPTION
Closes #12.

## What

The GO project reorganized its annotation file distribution ([geneontology/go-announcements#1153](https://github.com/geneontology/go-announcements/issues/1153)). The `/annotations` directory is split into `/gaf`, `/gpad`, `/gpi` subdirectories and files are renamed using **UniProt mnemonic organism codes**. Old URLs remain available through July 2026 and redirects expire **September 2026**, so this ingest must move to the new URLs.

This PR rewrites all 13 GAF download URLs to the new `/annotations/gaf/<MNEMONIC>-<variant>.gaf.gz` scheme.

## Variant choice

MOD files are now published in two variants. We use:

- **`-mod`** (MOD ID-centric) for MOD-submitted species — preserves MOD-namespace gene identifiers, matching current behavior.
- **`-uniprot`** for the UniProt-mediated species we previously took from `goa_*` files.

| Old basename | New basename | infores |
|---|---|---|
| `goa_human.gaf.gz` | `gaf/HUMAN-uniprot.gaf.gz` | goa-human |
| `mgi.gaf.gz` | `gaf/MOUSE-mod.gaf.gz` | mgi |
| `rgd.gaf.gz` | `gaf/RAT-mod.gaf.gz` | rgd |
| `goa_dog.gaf.gz` | `gaf/CANLF-uniprot.gaf.gz` | goa-dog |
| `goa_cow.gaf.gz` | `gaf/BOVIN-uniprot.gaf.gz` | goa-cow |
| `goa_pig.gaf.gz` | `gaf/PIG-uniprot.gaf.gz` | goa-pig |
| `goa_chicken.gaf.gz` | `gaf/CHICK-uniprot.gaf.gz` | goa-chicken |
| `zfin.gaf.gz` | `gaf/DANRE-mod.gaf.gz` | zfin |
| `fb.gaf.gz` | `gaf/DROME-mod.gaf.gz` | flybase |
| `wb.gaf.gz` | `gaf/CAEEL-mod.gaf.gz` | wormbase |
| `dictybase.gaf.gz` | `gaf/DICDI-mod.gaf.gz` | dictybase |
| `sgd.gaf.gz` | `gaf/YEAST-mod.gaf.gz` | sgd |
| `pombase.gaf.gz` | `gaf/SCHPO-mod.gaf.gz` | pombase |

## Changes

- **`download.yaml`** — all 13 GO annotation URLs updated. Local `local_name` taxid paths are unchanged, so `src/go_annotation.yaml` needs no changes.
- **`src/versions.py`** — `GAF_INFORES` keys updated to the new basenames (infores mappings unchanged).
- **`tests/test_versions.py`** — fixtures and the URL assertion updated to the new scheme.
- **`README.md`** — documented download path updated to `/annotations/gaf/`.

## Verification

- All 13 new URLs return HTTP 200 (HEAD-checked against `current.geneontology.org`).
- Confirmed every GAF basename in `download.yaml` is mapped in `GAF_INFORES` (the invariant `test_gaf_infores_covers_all_download_yaml_entries` enforces).

> Note: the full pytest suite could not be run in this environment because the `kozahub-metadata-schema` sibling dependency isn't reachable through the sandbox proxy. CI should run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014hLN7S141aPoL7YkTQ2yX2)_