### PR TITLE
Emit canonical biolink:active_in predicate (fixes monarch-app#1360)

### DIFF
--- a/src/annotation_utils.py
+++ b/src/annotation_utils.py
@@ -44,10 +44,11 @@ _gene_identifier_map: Dict[str, Tuple[str, Pattern]] = {
 
 
 # Create biolink predicate map in three steps
-# Define predicate terms
-# Map each term to its corresponding biolink predicate (1:1 "biolink:mapping" for all except involved_in)
-# Add exceptions to the rule where the term is not a 1:1 to biolink
-# (Currently 1 exception "involved_in" --> "actively_involved_in")
+# Define predicate terms (the values GO uses in the GAF "Qualifier" column)
+# Map each term to its corresponding biolink predicate (1:1 "biolink:mapping" for most)
+# Add exceptions to the rule where the GAF term is not a 1:1 to a biolink predicate slot:
+#   "involved_in"  --> "biolink:actively_involved_in" (RO:0002331)
+#   "is_active_in" --> "biolink:active_in"             (RO:0002432; biolink's slot is "active_in", not "is_active_in")
 predicate_terms = [
     "enables",
     "involved_in",
@@ -64,9 +65,9 @@ predicate_terms = [
     "acts_upstream_of_or_within_negative_effect",
 ]
 biolink_predicate_map = {pterm: "biolink:{}".format(pterm) for pterm in predicate_terms}
-biolink_predicate_map["involved_in"] = (
-    "biolink:actively_involved_in"  # Our one exception to the rule where the term is not a 1:1 to biolink
-)
+# Exceptions where the GAF qualifier term does not match the biolink predicate slot name 1:1
+biolink_predicate_map["involved_in"] = "biolink:actively_involved_in"
+biolink_predicate_map["is_active_in"] = "biolink:active_in"
 
 
 ### https://geneontology.org/docs/go-annotation-file-gaf-format-2.2/#aspect-column-9

--- a/src/go_annotation.py
+++ b/src/go_annotation.py
@@ -74,7 +74,9 @@ def transform_record(koza_transform, row):
     # a.k.a. predicate based on specified GO Aspect type
     if not qualifier:
         logger.error("GAF record is missing its qualifier...assigning default qualifier as per GO term Aspect")
-        predicate = aspect_map[go_aspect]
+        # Route the GAF aspect default through biolink_predicate_map so we always
+        # emit a real biolink predicate CURIE (never a bare term).
+        predicate = biolink_predicate_map[aspect_map[go_aspect]]
 
     else:
         # check for piped negation prefix (hopefully, well behaved!)

--- a/tests/test_go_annotations.py
+++ b/tests/test_go_annotations.py
@@ -504,18 +504,27 @@ def test_association(test_rows, mappings):
     # We expect 10 associations (11 rows - 1 skipped due to empty Aspect)
     assert len(entities) == 10
 
-    # Test first association (regular MolecularActivity)
-    association = entities[0]
-    assert association
-    assert association.subject in result_expected.keys()
+    # Every produced subject should be represented exactly once in result_expected
+    produced_subjects = [association.subject for association in entities]
+    assert len(produced_subjects) == len(set(produced_subjects)), "unexpected duplicate subjects"
 
-    assert association.object == result_expected[association.subject][2]
-    assert association.predicate == result_expected[association.subject][5]
-    assert association.negated == result_expected[association.subject][7]
-    assert result_expected[association.subject][8] in association.has_evidence
+    # Validate EVERY produced association, not just the first one. This guards
+    # against predicate regressions (e.g. is_active_in vs. active_in) that would
+    # otherwise slip through if only entities[0] were checked.
+    for association in entities:
+        assert association
+        assert association.subject in result_expected, f"unexpected subject {association.subject}"
+        expected = result_expected[association.subject]
 
-    assert association.primary_knowledge_source == "infores:uniprot"
-    assert "infores:monarchinitiative" in association.aggregator_knowledge_source
+        assert association.object == expected[2]
+        assert association.predicate == expected[5]
+        assert association.negated == expected[7]
+        assert expected[8] in association.has_evidence
+        assert "infores:monarchinitiative" in association.aggregator_knowledge_source
+
+    # Primary knowledge source is derived from the row's Assigned_By column;
+    # the first fixture row is assigned by UniProt.
+    assert entities[0].primary_knowledge_source == "infores:uniprot"
 
     # Taxon testing (multiple and single taxon values)
     single_taxa_association = entities[0]
@@ -603,6 +612,56 @@ def test_taxon_filter_covers_both_prefixes():
         f"NCBITaxon: prefixes; missing NCBITaxon: for {sorted(lower - ncbi)}, "
         f"missing taxon: for {sorted(ncbi - lower)}"
     )
+
+
+def _biolink_predicate_curies() -> set[str]:
+    """Return the set of valid biolink predicate CURIEs from the installed biolink model.
+
+    A predicate is any slot that is (transitively) ``is_a: related to``. We read
+    the schema YAML bundled with the ``biolink_model`` package so the check tracks
+    whatever biolink-model version this ingest depends on.
+    """
+    import importlib.util
+
+    spec = importlib.util.find_spec("biolink_model")
+    pkg_dir = Path(spec.submodule_search_locations[0])
+    schema_path = pkg_dir / "schema" / "biolink_model.yaml"
+    slots = yaml.safe_load(schema_path.read_text())["slots"]
+
+    def is_predicate(name: str) -> bool:
+        cur = name
+        while cur:
+            if cur == "related to":
+                return True
+            slot = slots.get(cur)
+            cur = slot.get("is_a") if slot else None
+        return False
+
+    return {"biolink:" + name.replace(" ", "_") for name in slots if is_predicate(name)}
+
+
+def test_only_real_biolink_predicates():
+    """Every predicate the transform can emit must be a real biolink predicate.
+
+    Guards monarch-app#1360: ``biolink:is_active_in`` is not a canonical biolink
+    predicate (the slot is ``active_in`` / RO:0002432).
+    """
+    from annotation_utils import aspect_map, biolink_predicate_map, qualifier_map
+
+    valid = _biolink_predicate_curies()
+    # sanity: the canonical slot exists and the non-canonical one does not
+    assert "biolink:active_in" in valid
+    assert "biolink:is_active_in" not in valid
+
+    # Collect every biolink predicate CURIE the transform can produce:
+    emitted = set(biolink_predicate_map.values())
+    # aspect_map defaults are routed through biolink_predicate_map at the use site
+    emitted |= {biolink_predicate_map[term] for term in aspect_map.values()}
+    # qualifier_map (ND root-node) defaults are likewise routed through biolink_predicate_map
+    emitted |= {biolink_predicate_map[q] for q in qualifier_map.values()}
+
+    invalid = sorted(p for p in emitted if p not in valid)
+    assert not invalid, f"transform emits non-biolink predicate(s): {invalid}"
 
 
 def test_empty_aspect_skipped(mappings):


### PR DESCRIPTION
GO cellular-component annotations were emitting biolink:is_active_in for the
RO:0002432 relation, but that is not a canonical Biolink predicate — the
Biolink slot is active_in. This broke predicate-definition resolution and
risked TRAPI/validation failures downstream.

- Map the GAF "is_active_in" qualifier to biolink:active_in, as an exception
  alongside the existing involved_in -> biolink:actively_involved_in.
- Route the missing-qualifier aspect fallback through biolink_predicate_map so
  it emits a real biolink CURIE instead of a bare term.
- Strengthen test_association to validate every produced association (not just
  the first), and add test_only_real_biolink_predicates, which checks that
  every predicate the transform can emit is a real Biolink predicate per the
  bundled biolink-model schema.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0117ugAdT4Ss4mCbXGE1YwKN